### PR TITLE
Update lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,6 +390,11 @@ impl Decal {
     Self { inner, sprite }
   }
 
+  pub fn new_p(sprite: &Sprite) -> Self {
+    let inner = unsafe { cpp::DecalConstructor(sprite.inner) };
+    Self { inner, sprite }
+  }
+
   /// Returns id of the decal.
   pub fn id(&self) -> i32 {
     unsafe { cpp::DecalId(&self.inner) }


### PR DESCRIPTION
created another constructor for `Decal` structure so that, it can take `Sprite` as immutable reference to construct itself (`Decal`).

This is to make sure `olc::Renderable` to be constructed.